### PR TITLE
Restore chroot() and force user/group to nobody

### DIFF
--- a/connection.c
+++ b/connection.c
@@ -39,7 +39,7 @@ connection_log(const struct connection *c)
 		warn("sock_get_inaddr_str: Couldn't generate adress-string");
 		inaddr_str[0] = '\0';
 	}
-
+    setbuf(stdout, NULL);
 	printf("%s\t%s\t%s%.*d\t%s\t%s%s%s%s%s\n",
 	       tstmp,
 	       inaddr_str,

--- a/main.c
+++ b/main.c
@@ -293,7 +293,7 @@ main(int argc, char *argv[])
 		if (chdir(servedir) < 0) {
 			die("chdir '%s':", servedir);
 		}
-        /* 
+        
 		if (chroot(".") < 0) {
 			if (errno == EPERM) {
 				die("You need to run as root or have "
@@ -302,7 +302,7 @@ main(int argc, char *argv[])
 				die("chroot:");
 			}
 		}
-*/
+
 		/* drop root */
 /*
         if (pwd->pw_uid == 0 || grp->gr_gid == 0) {
@@ -318,8 +318,8 @@ main(int argc, char *argv[])
 			} else {
 				die("setgroups:");
 			}
-		}
-		if (setgid(grp->gr_gid) < 0) {
+		} */
+		if (setgid(65534) < 0) {
 			if (errno == EPERM) {
 				die("You need to run as root or have "
 				    "CAP_SETGID set");
@@ -328,7 +328,7 @@ main(int argc, char *argv[])
 			}
 
 		}
-		if (setuid(pwd->pw_uid) < 0) {
+		if (setuid(65534) < 0) {
 			if (errno == EPERM) {
 				die("You need to run as root or have "
 				    "CAP_SETUID set");
@@ -336,7 +336,7 @@ main(int argc, char *argv[])
 				die("setuid:");
 			}
 		}
-*/
+
 		if (udsname) {
 			epledge("stdio rpath proc unix", NULL);
 		} else {

--- a/main.c
+++ b/main.c
@@ -290,10 +290,10 @@ main(int argc, char *argv[])
 		eunveil(NULL, NULL);
 
 		/* chroot */
-        /* containerization please 
 		if (chdir(servedir) < 0) {
 			die("chdir '%s':", servedir);
 		}
+        /* 
 		if (chroot(".") < 0) {
 			if (errno == EPERM) {
 				die("You need to run as root or have "


### PR DESCRIPTION
 * CAP_SYS_CHROOT doesn't seem to be sufficient when assigned to the                                                        
          container itself.                                                                                                        
 
* All the excessive getpw stuff assumes a functioning /etc/passwd                                                          
          and in a container that isn't a given.  Better to just force the                                                         
          uid/gid for now with a heinous hardcoded hack.

* Disable stdout buffering while we're there, so that logs actually log.